### PR TITLE
feat: add support for relationship labels

### DIFF
--- a/packages/common/lib/models/relationship.model.ts
+++ b/packages/common/lib/models/relationship.model.ts
@@ -2,10 +2,13 @@ import { TablePageConfig } from "./tablePage.model";
 
 interface RelationshipBase {
   key: string;
-  
+
   position?: number;
 
   hiddenInTable?: boolean;
+
+  /** Display name for the relation */
+  label?: string;
 }
 
 export type Relationship = OneToOneRelationship | OneToManyRelationship | ManyToManyRelationship;

--- a/packages/common/lib/utils/getTableData.ts
+++ b/packages/common/lib/utils/getTableData.ts
@@ -158,6 +158,7 @@ export function getTableData(params: {
       key: i.key,
       hiddenInTable: relationship?.hiddenInTable ?? false,
       position: relationship?.position ?? i.position,
+      label: relationship?.label,
     } as Relationship;
   });
   const sortedRelationships = sortRelationshipsByOrder(relationships);


### PR DESCRIPTION
This PR adds support for #59.

To make this work, a patch is needed to the @kottster/react packages. Something like

```
// TODO: remove, when getRelationshipDefaultData will be implemented
label: relationship.label ?? transformToReadable(relationship.targetTable)
```